### PR TITLE
Added functions to configure AutomaticWindowsUpdate and TCPIPv6

### DIFF
--- a/Sophia/LTSC/Sophia.ps1
+++ b/Sophia/LTSC/Sophia.ps1
@@ -703,6 +703,23 @@ SmartActiveHours -Enable
 # Do not automatically adjust active hours for me based on daily usage (default value)
 # Не изменять автоматически период активности для этого устройства на основе действий (значение по умолчанию)
 # SmartActiveHours -Disable
+
+# Enable Automatic Windows Update (default value)
+# Включить автоматическое обновление Windows (значение по умолчанию)
+# AutomaticWindowsUpdate -Enable
+
+# Disable Automatic Windows Update
+# Выключить автоматическое обновление Windows
+# AutomaticWindowsUpdate -Disable
+
+# Enable TCP/IPv6 across all Network Adapters (default value)
+# Включить TCP / IPv6 на всех сетевых адаптерах (значение по умолчанию)
+# TCPIPv6 -Enable
+
+# Disable TCP/IPv6 across all Network Adapters
+# Выключить TCP / IPv6 на всех сетевых адаптерах
+# TCPIPv6 -Disable
+
 #endregion System
 
 #region Start menu

--- a/Sophia/LTSC/Sophia.psm1
+++ b/Sophia/LTSC/Sophia.psm1
@@ -5556,6 +5556,115 @@ function SmartActiveHours
 		}
 	}
 }
+
+<#
+	.SYNOPSIS
+	Configure automatic windows update that includes cummulative, security, feature etc...
+
+	.PARAMETER Enable
+	Enable Automatic Windows Update 
+
+	.PARAMETER Disable
+	Disable Automatic Windows Update permanently
+
+	.EXAMPLE
+	AutomaticWindowsUpdate -Enable
+
+	.EXAMPLE
+	AutomaticWindowsUpdate -Disable
+
+	.NOTES
+	Machine-wide
+	Use Disable option with caution and only under specific situations when no automatic updates are required.
+	Manual updates are still possible when disabled.
+#>
+function AutomaticWindowsUpdate
+{
+	param
+	(
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Enable"
+		)]
+		[switch]
+		$Enable,
+
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Disable"
+		)]
+		[switch]
+		$Disable
+	)
+
+	switch ($PSCmdlet.ParameterSetName)
+	{
+		"Enable"
+		{
+			Remove-Item -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Force -ErrorAction SilentlyContinue
+		}
+		"Disable"
+		{
+			if (-not (Test-Path -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU))
+			{
+				New-Item -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Force
+			}
+			New-ItemProperty -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Name NoAutoUpdate -PropertyType DWord -Value 1 -Force
+		}
+	}
+}
+
+<#
+	.SYNOPSIS
+	Configure Internet Protocol version 6 - TCP/IPv6 Network Setting across all Network Adapters
+
+	.PARAMETER Enable
+	Enable TCP/IPv6 across all Network Adapters
+
+	.PARAMETER Disable
+	Disable TCP/IPv6 across all Network Adapters
+
+	.EXAMPLE
+	TCPIPv6 -Enable
+
+	.EXAMPLE
+	TCPIPv6 -Disable
+
+	.NOTES
+	Machine-wide
+#>
+function TCPIPv6
+{
+	param
+	(
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Enable"
+		)]
+		[switch]
+		$Enable,
+
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Disable"
+		)]
+		[switch]
+		$Disable
+	)
+
+	switch ($PSCmdlet.ParameterSetName)
+	{
+		"Enable"
+		{
+			Remove-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters -Name DisabledComponents -Force -ErrorAction SilentlyContinue
+		}
+		"Disable"
+		{
+			New-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters -Name DisabledComponents -PropertyType DWord -Value 255 -Force
+		}
+	}
+}
+
 #endregion System
 
 #region Start menu

--- a/Sophia/PowerShell 5.1/Sophia.ps1
+++ b/Sophia/PowerShell 5.1/Sophia.ps1
@@ -851,6 +851,23 @@ DeviceRestartAfterUpdate -Enable
 # Do not restart this device as soon as possible when a restart is required to install an update (default value)
 # Не перезапуск этого устройства как можно быстрее, если для установки обновления требуется перезагрузка (значение по умолчанию)
 # DeviceRestartAfterUpdate -Disable
+
+# Enable Automatic Windows Update (default value)
+# Включить автоматическое обновление Windows (значение по умолчанию)
+# AutomaticWindowsUpdate -Enable
+
+# Disable Automatic Windows Update
+# Выключить автоматическое обновление Windows
+# AutomaticWindowsUpdate -Disable
+
+# Enable TCP/IPv6 across all Network Adapters (default value)
+# Включить TCP / IPv6 на всех сетевых адаптерах (значение по умолчанию)
+# TCPIPv6 -Enable
+
+# Disable TCP/IPv6 across all Network Adapters
+# Выключить TCP / IPv6 на всех сетевых адаптерах
+# TCPIPv6 -Disable
+
 #endregion System
 
 #region WSL

--- a/Sophia/PowerShell 5.1/Sophia.psm1
+++ b/Sophia/PowerShell 5.1/Sophia.psm1
@@ -6649,6 +6649,115 @@ function DeviceRestartAfterUpdate
 		}
 	}
 }
+
+<#
+	.SYNOPSIS
+	Configure automatic windows update that includes cummulative, security, feature etc...
+
+	.PARAMETER Enable
+	Enable Automatic Windows Update 
+
+	.PARAMETER Disable
+	Disable Automatic Windows Update permanently
+
+	.EXAMPLE
+	AutomaticWindowsUpdate -Enable
+
+	.EXAMPLE
+	AutomaticWindowsUpdate -Disable
+
+	.NOTES
+	Machine-wide
+	Use Disable option with caution and only under specific situations when no automatic updates are required.
+	Manual updates are still possible when disabled.
+#>
+function AutomaticWindowsUpdate
+{
+	param
+	(
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Enable"
+		)]
+		[switch]
+		$Enable,
+
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Disable"
+		)]
+		[switch]
+		$Disable
+	)
+
+	switch ($PSCmdlet.ParameterSetName)
+	{
+		"Enable"
+		{
+			Remove-Item -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Force -ErrorAction SilentlyContinue
+		}
+		"Disable"
+		{
+			if (-not (Test-Path -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU))
+			{
+				New-Item -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Force
+			}
+			New-ItemProperty -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Name NoAutoUpdate -PropertyType DWord -Value 1 -Force
+		}
+	}
+}
+
+<#
+	.SYNOPSIS
+	Configure Internet Protocol version 6 - TCP/IPv6 Network Setting across all Network Adapters
+
+	.PARAMETER Enable
+	Enable TCP/IPv6 across all Network Adapters
+
+	.PARAMETER Disable
+	Disable TCP/IPv6 across all Network Adapters
+
+	.EXAMPLE
+	TCPIPv6 -Enable
+
+	.EXAMPLE
+	TCPIPv6 -Disable
+
+	.NOTES
+	Machine-wide
+#>
+function TCPIPv6
+{
+	param
+	(
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Enable"
+		)]
+		[switch]
+		$Enable,
+
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Disable"
+		)]
+		[switch]
+		$Disable
+	)
+
+	switch ($PSCmdlet.ParameterSetName)
+	{
+		"Enable"
+		{
+			Remove-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters -Name DisabledComponents -Force -ErrorAction SilentlyContinue
+		}
+		"Disable"
+		{
+			New-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters -Name DisabledComponents -PropertyType DWord -Value 255 -Force
+		}
+	}
+}
+
 #endregion System
 
 #region WSL

--- a/Sophia/PowerShell 7.x/Sophia.ps1
+++ b/Sophia/PowerShell 7.x/Sophia.ps1
@@ -851,6 +851,23 @@ DeviceRestartAfterUpdate -Enable
 # Do not restart this device as soon as possible when a restart is required to install an update (default value)
 # Не перезапуск этого устройства как можно быстрее, если для установки обновления требуется перезагрузка (значение по умолчанию)
 # DeviceRestartAfterUpdate -Disable
+
+# Enable Automatic Windows Update (default value)
+# Включить автоматическое обновление Windows (значение по умолчанию)
+# AutomaticWindowsUpdate -Enable
+
+# Disable Automatic Windows Update
+# Выключить автоматическое обновление Windows
+# AutomaticWindowsUpdate -Disable
+
+# Enable TCP/IPv6 across all Network Adapters (default value)
+# Включить TCP / IPv6 на всех сетевых адаптерах (значение по умолчанию)
+# TCPIPv6 -Enable
+
+# Disable TCP/IPv6 across all Network Adapters
+# Выключить TCP / IPv6 на всех сетевых адаптерах
+# TCPIPv6 -Disable
+
 #endregion System
 
 #region WSL

--- a/Sophia/PowerShell 7.x/Sophia.psm1
+++ b/Sophia/PowerShell 7.x/Sophia.psm1
@@ -6665,6 +6665,115 @@ function DeviceRestartAfterUpdate
 		}
 	}
 }
+
+<#
+	.SYNOPSIS
+	Configure automatic windows update that includes cummulative, security, feature etc...
+
+	.PARAMETER Enable
+	Enable Automatic Windows Update 
+
+	.PARAMETER Disable
+	Disable Automatic Windows Update permanently
+
+	.EXAMPLE
+	AutomaticWindowsUpdate -Enable
+
+	.EXAMPLE
+	AutomaticWindowsUpdate -Disable
+
+	.NOTES
+	Machine-wide
+	Use Disable option with caution and only under specific situations when no automatic updates are required.
+	Manual updates are still possible when disabled.
+#>
+function AutomaticWindowsUpdate
+{
+	param
+	(
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Enable"
+		)]
+		[switch]
+		$Enable,
+
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Disable"
+		)]
+		[switch]
+		$Disable
+	)
+
+	switch ($PSCmdlet.ParameterSetName)
+	{
+		"Enable"
+		{
+			Remove-Item -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Force -ErrorAction SilentlyContinue
+		}
+		"Disable"
+		{
+			if (-not (Test-Path -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU))
+			{
+				New-Item -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Force
+			}
+			New-ItemProperty -Path HKLM:\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU -Name NoAutoUpdate -PropertyType DWord -Value 1 -Force
+		}
+	}
+}
+
+<#
+	.SYNOPSIS
+	Configure Internet Protocol version 6 - TCP/IPv6 Network Setting across all Network Adapters
+
+	.PARAMETER Enable
+	Enable TCP/IPv6 across all Network Adapters
+
+	.PARAMETER Disable
+	Disable TCP/IPv6 across all Network Adapters
+
+	.EXAMPLE
+	TCPIPv6 -Enable
+
+	.EXAMPLE
+	TCPIPv6 -Disable
+
+	.NOTES
+	Machine-wide
+#>
+function TCPIPv6
+{
+	param
+	(
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Enable"
+		)]
+		[switch]
+		$Enable,
+
+		[Parameter(
+			Mandatory = $true,
+			ParameterSetName = "Disable"
+		)]
+		[switch]
+		$Disable
+	)
+
+	switch ($PSCmdlet.ParameterSetName)
+	{
+		"Enable"
+		{
+			Remove-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters -Name DisabledComponents -Force -ErrorAction SilentlyContinue
+		}
+		"Disable"
+		{
+			New-ItemProperty -Path HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters -Name DisabledComponents -PropertyType DWord -Value 255 -Force
+		}
+	}
+}
+
 #endregion System
 
 #region WSL


### PR DESCRIPTION
AutomaticWindowsUpdate - Configure automatic windows update
TCPIPv6 - Configure TCP/IPv6 Network Setting across all Network Adapters

The above functions are very useful under certain conditions where 
- Windows updates should not be enabled or PC will never have access to internet
- TCPIPv6 causes networking issues and needs to be disabled